### PR TITLE
feat: add PR review command (#3)

### DIFF
--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -1,0 +1,77 @@
+Review GitHub Pull Request and provide insights for human reviewers: $ARGUMENTS
+
+Output language: Japanese, formal business tone
+
+## Prerequisites
+
+- gh CLI installed and authenticated
+- $ARGUMENTS: PR number (123) or URL
+- Run from repo root
+
+## Process
+
+1. Fetch PR information: `gh pr view $ARGUMENTS`
+2. Fetch PR diff: `gh pr diff $ARGUMENTS`
+3. Analyze the changes using Task tool (subagent_type=general-purpose) with focus on:
+   - Code quality and design (naming conventions, function responsibilities, readability)
+   - Security risks (vulnerabilities, secret leaks, OWASP top 10)
+   - Performance (processing speed, memory usage, inefficient implementations)
+   - Test adequacy (coverage, test case appropriateness)
+4. Provide essential context for human reviewers
+5. Output comprehensive review report in Markdown format
+
+## Output Format
+
+The review should be structured as follows:
+
+```markdown
+# PR一次レビュー結果
+
+## 変更サマリー
+[What was changed and why - include architectural decisions, affected components, scope of changes]
+
+## Claudeによる一次レビュー
+
+### コードの品質・設計
+[Analysis of code quality, design patterns, naming conventions, function responsibilities, readability]
+- 具体的な問題点や改善提案があれば、ファイルパスと行番号を含めて記載
+
+### セキュリティリスク
+[Security vulnerability analysis including XSS, SQL injection, authentication issues, secret exposure risks]
+- 問題が見つかった場合は、WARNING として明示し、具体的な対策を提案
+
+### パフォーマンス
+[Performance analysis including algorithmic complexity, memory usage, database queries, caching opportunities]
+- パフォーマンス上の懸念があれば、具体的な影響範囲と改善案を記載
+
+### テストの妥当性
+[Test coverage analysis, test case appropriateness, edge cases, integration tests]
+- 不足しているテストケースがあれば具体的に指摘
+
+## レビューに必要な情報
+
+### 変更の背景とコンテキスト
+[Why these changes were made, related issues, design decisions, architectural considerations]
+
+### 影響範囲
+[What parts of the system are affected, potential side effects, downstream dependencies]
+
+### 確認が必要な項目
+[Specific aspects that require human judgment - business logic validation, edge cases, integration points]
+1. [Item requiring validation]
+2. [Complex logic requiring domain expertise]
+3. [Breaking changes or API changes]
+
+### 関連ファイルと依存関係
+[Files that are related but not changed, dependencies that might be affected, configuration changes needed]
+```
+
+## Notes
+
+- Focus on providing context that is not obvious from reading the PR description
+- If PR diff is too large (>10 files or >500 lines), focus on critical changes
+- For security issues, mark them clearly with WARNING and provide specific remediation steps
+- Provide actionable feedback with concrete suggestions
+- Highlight breaking changes or backward compatibility concerns
+- Consider integration points and system-wide impact
+- Omit redundant information that can be easily seen in the PR itself (title, author, file list, etc.)


### PR DESCRIPTION
## 概要
GitHub PRの一次レビューを行う `/review-pr` コマンドを実装しました。

## 実装内容
- `commands/review-pr.md` に新しいコマンドファイルを作成
- 以下の4つの観点で自動レビューを実施:
  - コードの品質・設計（命名規則、関数の責務、可読性など）
  - セキュリティリスク（脆弱性、機密情報の漏洩リスクなど）
  - パフォーマンス（処理速度、メモリ使用量、非効率な実装など）
  - テストの妥当性（カバレッジ、テストケースの適切さなど）

## レビュー結果の出力内容
人間のレビュアーがレビューする際に必要な情報を提供:
- **変更サマリー**: 何が変更されたか、アーキテクチャ上の決定事項、影響を受けるコンポーネント
- **Claudeによる一次レビュー**: 4つの観点での分析結果
- **レビューに必要な情報**:
  - 変更の背景とコンテキスト
  - 影響範囲
  - 確認が必要な項目
  - 関連ファイルと依存関係

## 使用方法
```
/review-pr [PR番号]
```

## テスト方法
- このPR自体を使って動作確認可能: `/review-pr 4`

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)