### PR TITLE
feat: コマンド改善提案を自動生成するimprove-commandを追加 (#8)

### DIFF
--- a/commands/improve-command.md
+++ b/commands/improve-command.md
@@ -25,6 +25,7 @@ Output language: Japanese, formal business tone
    - Note additional steps required beyond command specification
    - Find workarounds or fixes applied
 3. Analyze git history:
+   - Check if current repository is private: `gh repo view --json isPrivate`
    - Get recent commits: `git log --oneline -10`
    - Identify related PR: `gh pr list --limit 5`
    - Extract actual implementation changes
@@ -42,7 +43,7 @@ Output language: Japanese, formal business tone
      - 実際に発生した問題: Concrete problems encountered
      - 改善提案: Specific proposals with code samples
      - 期待される効果: Expected benefits
-     - 参考: Links to relevant PRs/commits
+     - 参考: Links to relevant PRs/commits (only if repository is public)
 6. Create GitHub issue:
    - Use `gh issue create` with generated content
    - Target repository: toumakido/my-claude
@@ -83,6 +84,8 @@ Output language: Japanese, formal business tone
 
 ## 参考
 
+(このセクションは作業対象リポジトリがpublicの場合のみ含める)
+
 - PR: [PR URL]
 - Commit: [commit hash/URL]
 ```
@@ -118,5 +121,6 @@ Output language: Japanese, formal business tone
 - This command works best when executed immediately after target command usage
 - Longer conversation history provides more context for analysis
 - Include specific code examples in proposals for clarity
-- Link to actual commits/PRs as evidence of issues
+- For public repositories: Include PR/commit links as evidence
+- For private repositories: Omit PR/commit links from issue (not accessible to public)
 - Consider both technical gaps and documentation improvements


### PR DESCRIPTION
## Summary

コマンド使用後の作業履歴を分析し、改善提案をGitHub issueとして自動生成する `/improve-command` コマンドを実装。

## Features

### 1. 会話履歴とgit履歴の統合分析
- 対象コマンド実行後の作業内容を会話履歴から抽出
- git履歴（commit、PR）から実際の変更内容を確認
- 問題点、追加手順、ワークアラウンドを特定

### 2. 構造化されたissue生成
- 実際に発生した問題
- 具体的な改善提案（コードサンプル付き）
- 期待される効果
- 参考となるPR/commitリンク

### 3. 継続的改善サイクルの確立
コマンド実行 → `/improve-command` 実行 → Issue作成 → コマンド更新 → 改善されたコマンドで次回実装

## Usage

同じ会話セッション内で：
```
/migrate-aws-sdk
[実装作業]
/improve-command migrate-aws-sdk
```

## Implementation Details

- 対象コマンドファイル（`commands/<name>.md`）の検証
- 会話コンテキストからの問題点抽出
- git履歴解析（`git log`、`gh pr list`）
- テンプレートベースのissue本文生成
- `gh issue create` によるissue作成

## Benefits

- コマンドの実用的な改善点を体系的に蓄積
- 手戻りや非効率な部分を迅速に特定
- 次回以降の作業効率向上
- 実際の使用例に基づく改善

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)