### PR TITLE
fix: GitHub関連の署名削除と出力簡略化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,3 +43,19 @@ Example: "Retry 3 times due to API rate limits" (good) vs "increment i" (bad)
 ## Edit Tool
 
 Combine related changes in single Edit, especially imports with usage code
+
+# Git Commit
+
+DO NOT include these in commit messages:
+- "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+- "Co-Authored-By: Claude <noreply@anthropic.com>"
+
+Commit format:
+```
+<type>: <brief> (#<issue_number>)
+
+- details
+- scope
+
+Fixes #<issue_number>
+```

--- a/commands/work-on-issue.md
+++ b/commands/work-on-issue.md
@@ -25,13 +25,9 @@ fix: <brief> (#$ISSUE_NUMBER)
 - scope
 
 Fixes #$ISSUE_NUMBER
-
-Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
 ```
 9. Create PR with `gh pr create`, include: problem summary, fix details, test method, screenshots (if UI), Fixes #$ISSUE_NUMBER
-10. Show PR URL
+10. Output only: `https://github.com/user/repo/pull/123`
 
 ## Error Handling
 


### PR DESCRIPTION
## 変更内容

- CLAUDE.md: Git Commitルールを追加し、Claude Code署名の削除を明示
- commands/work-on-issue.md: commitメッセージフォーマットから署名を削除、PR作成後の出力をURLのみに簡略化

Fixes #19