### PR TITLE
optimize: AI efficiency for improve-command (20251122)

### DIFF
--- a/commands/improve-command.md
+++ b/commands/improve-command.md
@@ -40,10 +40,11 @@ Output language: Japanese, formal business tone
    - Additional questions needed during execution - count AskUserQuestion tool calls during command execution
    - Post-command fixes by user - commits/edits after command completion
 
-   **Check repository type** (for reference links in issue):
+   **Check repository type** (for reference links and generalization in later steps):
    - Run: `gh repo view --json isPrivate -q .isPrivate`
+   - Store result as `IS_PRIVATE` for use in Steps 5.6 and 5.7
    - If repository is public: Collect PR/commit references for issue body using `gh pr list --limit 5`
-   - If repository is private: Skip reference collection (will use generalized examples only)
+   - If repository is private: Skip reference collection (will apply generalization in Step 5.6)
 4. Extract improvement opportunities:
    - Missing patterns or examples
    - Insufficient guidance or documentation
@@ -134,13 +135,14 @@ Output language: Japanese, formal business tone
    追加・削除・修正したい項目があれば教えてください。
    ```
 
-5.6. Apply generalization for private repositories (if applicable):
+5.6. Apply generalization for private repositories:
+
+   **Condition**: Execute this step ONLY if `IS_PRIVATE` is true (determined in Step 3)
 
    **Purpose**: Automatically generalize code examples and identifiers when working repository is private
 
    **Actions**:
-   1. Check if working repository is private (already done in Step 3)
-   2. If private, apply generalization patterns to issue body:
+   1. Apply generalization patterns to issue body:
 
       **Automatic pattern matching and replacement**:
 
@@ -189,9 +191,9 @@ Output language: Japanese, formal business tone
       - calculateMonthlyFee → calculateValue
       ```
 
-   4. Apply replacements to issue body using regex patterns
-   5. Maintain consistency: same term → same generic name throughout issue body
-   6. Track generalization count (functions, repositories, domain terms) for Step 5.7
+   2. Apply replacements to issue body using regex patterns
+   3. Maintain consistency: same term → same generic name throughout issue body
+   4. Track generalization count (functions, repositories, domain terms) for Step 5.7
 
    **Implementation guideline**:
    - Use regex patterns to detect domain-specific terms
@@ -203,7 +205,9 @@ Output language: Japanese, formal business tone
      - **Level 3 (MAY keep specific)**: FilterExpression structure, query patterns, AWS service names
      - **Level 4 (MUST keep specific)**: Language keywords, standard library, common patterns
 
-5.7. Confirm generalized content with user (for private repositories):
+5.7. Confirm generalized content with user:
+
+   **Condition**: Execute this step ONLY if Step 5.6 was executed (i.e., `IS_PRIVATE` is true)
 
    **Purpose**: Ensure generalization is appropriate before creating public issue
 
@@ -249,11 +253,22 @@ Output language: Japanese, formal business tone
    ```
 
 6. Create GitHub issue:
+
+   **Flow**:
+   - If `IS_PRIVATE` is false (public repository):
+     - Proceed directly to issue creation
+   - If `IS_PRIVATE` is true (private repository):
+     - Steps 5.6 and 5.7 have been executed
+     - Use generalized issue body from Step 5.6
+     - User has approved content in Step 5.7
+
+   **Actions**:
    - Determine target repository:
      - Check current repository: `gh repo view --json nameWithOwner -q .nameWithOwner`
      - If current repository is toumakido/my-claude: Create issue here
      - Otherwise: Confirm with user or default to https://github.com/toumakido/my-claude
    - Use `gh issue create --repo toumakido/my-claude` with generated content
+
 7. Display created issue URL
 
 ## Issue Template Format


### PR DESCRIPTION
## Summary

### Files Modified
- commands/improve-command.md: Clarified generalization flow and execution conditions

### Improvements

1. **AI Efficiency: Added explicit execution conditions**
   - Step 5.6: Added "Execute this step ONLY if IS_PRIVATE is true" condition
   - Step 5.7: Added "Execute this step ONLY if Step 5.6 was executed" condition
   - Removed ambiguous "if applicable" phrasing

2. **Redundancy: Removed duplicate repository check**
   - Deleted redundant "Check if working repository is private" from Step 5.6.1
   - Reuse IS_PRIVATE variable from Step 3 instead of re-checking

3. **Structure: Clarified data flow**
   - Step 3: Store repository type as IS_PRIVATE for later use
   - Step 6: Added Flow section documenting public vs private paths
   - Separated Flow and Actions in Step 6

4. **Execution: Improved step numbering**
   - Step 5.6: Renumbered actions 4→2, 5→3, 6→4 after removing redundant check

### Before/After Examples

#### Example 1: Explicit execution condition (Step 5.6)

**Before** (ambiguous):
```
5.6. Apply generalization for private repositories (if applicable):

   **Purpose**: Automatically generalize code examples and identifiers when working repository is private

   **Actions**:
   1. Check if working repository is private (already done in Step 3)
   2. If private, apply generalization patterns to issue body:
```

**After** (explicit):
```
5.6. Apply generalization for private repositories:

   **Condition**: Execute this step ONLY if `IS_PRIVATE` is true (determined in Step 3)

   **Purpose**: Automatically generalize code examples and identifiers when working repository is private

   **Actions**:
   1. Apply generalization patterns to issue body:
```

#### Example 2: Data flow clarification (Step 3)

**Before**:
```
   **Check repository type** (for reference links in issue):
   - Run: `gh repo view --json isPrivate -q .isPrivate`
   - If repository is public: Collect PR/commit references for issue body using `gh pr list --limit 5`
   - If repository is private: Skip reference collection (will use generalized examples only)
```

**After** (explicit storage and reference):
```
   **Check repository type** (for reference links and generalization in later steps):
   - Run: `gh repo view --json isPrivate -q .isPrivate`
   - Store result as `IS_PRIVATE` for use in Steps 5.6 and 5.7
   - If repository is public: Collect PR/commit references for issue body using `gh pr list --limit 5`
   - If repository is private: Skip reference collection (will apply generalization in Step 5.6)
```

#### Example 3: Flow documentation (Step 6)

**Before** (implicit flow):
```
6. Create GitHub issue:
   - Determine target repository:
     - Check current repository: `gh repo view --json nameWithOwner -q .nameWithOwner`
     - If current repository is toumakido/my-claude: Create issue here
     - Otherwise: Confirm with user or default to https://github.com/toumakido/my-claude
   - Use `gh issue create --repo toumakido/my-claude` with generated content
```

**After** (explicit flow):
```
6. Create GitHub issue:

   **Flow**:
   - If `IS_PRIVATE` is false (public repository):
     - Proceed directly to issue creation
   - If `IS_PRIVATE` is true (private repository):
     - Steps 5.6 and 5.7 have been executed
     - Use generalized issue body from Step 5.6
     - User has approved content in Step 5.7

   **Actions**:
   - Determine target repository:
     - Check current repository: `gh repo view --json nameWithOwner -q .nameWithOwner`
     - If current repository is toumakido/my-claude: Create issue here
     - Otherwise: Confirm with user or default to https://github.com/toumakido/my-claude
   - Use `gh issue create --repo toumakido/my-claude` with generated content
```

### Impact

- Improved AI interpretation by clarifying when Steps 5.6 and 5.7 execute
- Reduced redundancy by reusing IS_PRIVATE variable
- Enhanced maintainability with explicit flow documentation
- Eliminated ambiguity around generalization execution conditions

### Testing

Manual review of command specification:
- ✓ IS_PRIVATE variable defined in Step 3 and referenced in Steps 5.6, 5.7, and 6
- ✓ Execution conditions explicitly stated for conditional steps
- ✓ Flow documentation clarifies public vs private repository paths
- ✓ No functional changes to command behavior

Fixes #73