### PR TITLE
refactor: migrate commands to skills and optimize CLAUDE.md (#102)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,6 @@ Before using packages:
 - Stdlib: verify with `go doc <package>` if uncertain
 - Third-party: Read go.mod first. If missing: ask user, then `go get`, then use
 
-## Compile Errors
-
-Fix all editor-detected errors before completing (undefined vars, type mismatches, missing imports, nonexistent fields/methods)
-
 ## Comments
 
 Write only:

--- a/README.md
+++ b/README.md
@@ -4,27 +4,48 @@
 
 ## 構成
 
-- `CLAUDE.md` - Claude Code全体のルール設定
-- `commands/` - カスタムコマンド
+- `CLAUDE.md` - Claude Code全体のルール設定（約45行に最適化）
+- `skills/` - カスタムスキル（メインの拡張機能）
 - `agents/` - カスタムエージェント定義
-- `skills/` - カスタムスキル
+- `commands/` - レガシーコマンド（aws-sdk-go-v2関連のみ）
 
-### commands/ ディレクトリの設計原則
+### skills/ (推奨)
 
-このディレクトリのマークダウンファイルはClaude CodeがAIとして読み取り実行するためのものです。編集時は以下を優先してください：
+GitHub issue/PR ワークフロー用のカスタムスキル:
+- `structure-issue` - GitHub issue作成
+- `restructure-issue` - 既存issue整理
+- `answer-issue` - issue調査・回答
+- `work-on-issue` - issue対応（実装・PR作成）
+- `review-pr` - PR一次レビュー
+- `verify-pr` - PR動作確認手順生成
+- `impl-review` - PRレビューコメント実装
+- `list-unresolved-pr-comments` - PR未解決コメント一覧
+- `improve-command` - スキル改善提案作成（手動呼び出し専用）
+- `optimize-ai-efficiency` - スキル最適化PR作成（手動呼び出し専用）
+- `pr-creator` - PR作成ガイド
 
-- **AI判断の効率性 > 人間の可読性**
-- ルールベース構造（if X then Y、パターンマッチング）
-- 判断フローを順序付きルールで明確化
-- 絵文字不使用（代わりにテキストマーカー: Correct:/Wrong:）
+### commands/ (レガシー)
+
+後方互換性のため保持。新しいワークフローは `skills/` に作成してください。
+
+現在保持されているコマンド:
+- `aws-sdk-go-v2/migrate` - AWS SDK v1→v2移行
+- `aws-sdk-go-v2/extract-chains` - SDK呼び出しチェーン抽出
+- `aws-sdk-go-v2/prepare-tests` - テストコード準備
 
 ## シンボリックリンク設定
 
 このリポジトリの以下のファイル/ディレクトリは `~/.claude/` とシンボリックリンクで同期されています：
 
 - `./CLAUDE.md` ↔ `~/.claude/CLAUDE.md`
-- `./commands/` ↔ `~/.claude/commands/`
+- `./skills/` ↔ `~/.claude/skills/`
 - `./agents/` ↔ `~/.claude/agents/`
-- `./skills/` 内の各スキル ↔ `~/.claude/skills/`
+- `./commands/` ↔ `~/.claude/commands/` (aws-sdk-go-v2用)
 
-**重要**: Claude Code に関する設定変更を依頼する場合は、必ずこのリポジトリ内のファイル（`./CLAUDE.md`, `./commands/`, `./agents/`, `./skills/`）を操作してください。`~/.claude/` 配下を直接操作しないでください。
+**重要**: Claude Code に関する設定変更を依頼する場合は、必ずこのリポジトリ内のファイル（`./CLAUDE.md`, `./skills/`, `./agents/`, `./commands/`）を操作してください。`~/.claude/` 配下を直接操作しないでください。
+
+## 備考
+
+- [公式ドキュメント](https://code.claude.com/docs/en/skills)によると、commandsはskillsに統合されました
+- 同名のskillとcommandがある場合、skillが優先されます
+- 既存のcommands/は後方互換性のため動作を継続しますが、新規作成はskills/を使用してください

--- a/skills/answer-issue/SKILL.md
+++ b/skills/answer-issue/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: answer-issue
+description: Efficiently answer question about GitHub issue
+---
+
 Efficiently answer question about GitHub issue $ARGUMENTS
 
 Output language: Japanese, formal business tone

--- a/skills/impl-review/SKILL.md
+++ b/skills/impl-review/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: impl-review
+description: GitHub PR Review Comment Implementation
+---
+
 # GitHub PR Review Comment Implementation
 
 GitHub PRのレビューコメントURLから指摘事項を分析し、実装まで行います。

--- a/skills/improve-command/SKILL.md
+++ b/skills/improve-command/SKILL.md
@@ -1,18 +1,24 @@
-Analyze command usage and create improvement proposal issue
+---
+name: improve-command
+description: Analyze skill usage and create improvement proposal issue
+disable-model-invocation: true
+---
+
+Analyze skill usage and create improvement proposal issue
 
 Output language: Japanese, formal business tone
 
 ## Prerequisites
 
 - gh CLI installed and authenticated
-- Must be executed in same conversation session after using target command
-- Working repository: Can be any repository where the command was used
+- Must be executed in same conversation session after using target skill
+- Working repository: Can be any repository where the skill was used
 - Issue target repository: https://github.com/toumakido/my-claude (determined dynamically or confirmed with user)
 
 ## Parameters
 
-- `$ARGUMENTS`: Target command name to improve (e.g., `migrate-aws-sdk`, `review-pr`, `improve-command`)
-  - Must correspond to a file in `commands/` directory (without `.md` extension)
+- `$ARGUMENTS`: Target skill name to improve (e.g., `migrate-aws-sdk`, `review-pr`, `improve-command`)
+  - Must correspond to a file in `skills/` directory (without `/SKILL.md` path)
   - Can be used recursively to improve improve-command itself
 
 ## Usage
@@ -24,21 +30,21 @@ Output language: Japanese, formal business tone
 
 ## Process
 
-1. Validate target command:
-   - Check if `commands/<command-name>.md` exists using Read tool
-   - If not found: Display error and list available commands (see Error Handling)
+1. Validate target skill:
+   - Check if `skills/<skill-name>/SKILL.md` exists using Read tool
+   - If not found: Display error and list available skills (see Error Handling)
 2. Analyze conversation history:
-   - Identify when target command was executed (search for `/command-name` in conversation)
+   - Identify when target skill was executed (search for `/skill-name` in conversation)
    - Extract problems encountered during/after execution
    - Identify missing patterns or guidance
-   - Note additional steps required beyond command specification
+   - Note additional steps required beyond skill specification
    - Find workarounds or fixes applied
 3. Analyze improvement opportunities from conversation history:
    - User corrections or指摘 (e.g., "周りのフォーマットに合わせて") - indicates missing style guidelines
    - Multiple Edit rejections indicating unclear requirements - count rejections with same file
    - Workarounds or manual interventions required - user ran commands directly
-   - Additional questions needed during execution - count AskUserQuestion tool calls during command execution
-   - Post-command fixes by user - commits/edits after command completion
+   - Additional questions needed during execution - count AskUserQuestion tool calls during skill execution
+   - Post-skill fixes by user - commits/edits after skill completion
 
    **Check repository type** (for reference links and generalization in later steps):
    - Run: `gh repo view --json isPrivate -q .isPrivate`
@@ -53,23 +59,23 @@ Output language: Japanese, formal business tone
    - More efficient approaches
 4.5. Categorize issues by improvement scope:
 
-   **Purpose**: Distinguish between command specification issues and implementation-phase issues
+   **Purpose**: Distinguish between skill specification issues and implementation-phase issues
 
    **Categories**:
 
-   1. **Command specification issues** (Should be included in improvement proposal):
-      - Missing or unclear steps in command process
-      - Insufficient guidance or examples in command documentation
-      - Lack of error handling patterns in command specification
+   1. **Skill specification issues** (Should be included in improvement proposal):
+      - Missing or unclear steps in skill process
+      - Insufficient guidance or examples in skill documentation
+      - Lack of error handling patterns in skill specification
       - Missing validation steps
       - Unclear decision criteria (e.g., when to apply certain patterns)
 
       Examples:
-      - "Command doesn't specify how to handle duplicate test data"
+      - "Skill doesn't specify how to handle duplicate test data"
       - "No guidance on determining test data distribution strategy"
       - "Missing step for validating type information"
 
-   2. **Implementation-phase issues** (Should be excluded from command specification):
+   2. **Implementation-phase issues** (Should be excluded from skill specification):
       - Technology-specific breaking changes (e.g., SDK version differences)
       - Library-specific behavior patterns
       - Domain-specific business logic
@@ -82,15 +88,15 @@ Output language: Japanese, formal business tone
 
    **Action**:
    - Review all identified issues and categorize them
-   - Only include command specification issues in improvement proposal
+   - Only include skill specification issues in improvement proposal
    - Document excluded implementation-phase issues separately (if requested by user)
 
 4.6. Evaluate severity and confirm with user:
    - Severity levels:
-     - Critical/Important: コマンド仕様の明確な不足、複数回の指摘 → Proceed to step 5
+     - Critical/Important: スキル仕様の明確な不足、複数回の指摘 → Proceed to step 5
      - Nice-to-have/None: 軽微な改善、1回のみの指摘、改善点なし → Use AskUserQuestion to confirm before proceeding to step 5
 5. Generate structured issue content (if confirmed):
-   - Title: `<command-name>.md の改善提案: [主要な改善点の要約]`
+   - Title: `<skill-name>.md の改善提案: [主要な改善点の要約]`
    - Body sections:
      - 概要: Brief summary of improvements
      - 実際に発生した問題: Concrete problems encountered
@@ -276,7 +282,7 @@ Output language: Japanese, formal business tone
 ```markdown
 ## 概要
 
-`commands/<command-name>.md` コマンドを実際のプロジェクトで使用した結果、いくつかの重要な改善点が判明しました。
+`skills/<skill-name>/SKILL.md` スキルを実際のプロジェクトで使用した結果、いくつかの重要な改善点が判明しました。
 
 ## 実際に発生した問題
 
@@ -318,10 +324,10 @@ Output language: Japanese, formal business tone
 - Look for multiple commits on same topic (indicates iterative fixes)
 - Check PR review comments for gaps in initial implementation
 - Identify patterns where manual intervention was required
-- Note deviations from command specification
+- Note deviations from skill specification
 
 ### Extracting Improvements
-- Compare command specification with actual implementation steps
+- Compare skill specification with actual implementation steps
 - Identify missing error handling patterns
 - Note service-specific details not covered
 - Consider validation steps that could prevent issues
@@ -333,8 +339,8 @@ Output language: Japanese, formal business tone
 
 ## Error Handling
 
-- Command file not found: Display error and list available commands
-- No recent usage found: Ask user to confirm command was used in current session
+- Skill file not found: Display error and list available skills
+- No recent usage found: Ask user to confirm skill was used in current session
 - No git history: Warn user but continue with conversation analysis only
 - gh CLI error: Display error and ask user to check authentication
 
@@ -402,7 +408,7 @@ func (repo *EntityRepository) FetchEntities(ctx context.Context, filterKey strin
 
 ## Notes
 
-- This command works best when executed immediately after target command usage
+- This skill works best when executed immediately after target skill usage
 - Longer conversation history provides more context for analysis
 - Include specific code examples in proposals for clarity
 - For public repositories: Include PR/commit links as evidence

--- a/skills/list-unresolved-pr-comments/SKILL.md
+++ b/skills/list-unresolved-pr-comments/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: list-unresolved-pr-comments
 description: 指定したPRの未解決レビューコメントを一覧表示
 args:
   pr_number:

--- a/skills/optimize-ai-efficiency/SKILL.md
+++ b/skills/optimize-ai-efficiency/SKILL.md
@@ -1,11 +1,17 @@
-Review and optimize commands and CLAUDE.md for AI efficiency: $ARGUMENTS
+---
+name: optimize-ai-efficiency
+description: Review and optimize skills and CLAUDE.md for AI efficiency
+disable-model-invocation: true
+---
+
+Review and optimize skills and CLAUDE.md for AI efficiency: $ARGUMENTS
 
 Output language: Japanese, formal business tone
 
 ## Prerequisites
 
 - Must run from toumakido/my-claude repository root
-- This command only works for toumakido/my-claude repository
+- This skill only works for toumakido/my-claude repository
 - gh CLI installed and authenticated
 - Git working tree clean
 - $ARGUMENTS: Optional file paths (space-separated). If empty, all files are targeted.
@@ -19,7 +25,7 @@ Output language: Japanese, formal business tone
      - If any file doesn't exist: output error and exit
      - Use specified files as target list
    - If $ARGUMENTS is empty:
-     - Target all files: `commands/*.md`, `CLAUDE.md`, `.claude/*` (if exists)
+     - Target all files: `skills/*/SKILL.md`, `CLAUDE.md`, `.claude/*` (if exists)
 
 2. Read and analyze target files from step 1
 
@@ -53,7 +59,7 @@ Bad: Run tests if needed
 Good: If changes affect core logic: run `npm test`
 
 Bad: Update the file
-Good: Update `commands/example.md` using Edit tool
+Good: Update `skills/example/SKILL.md` using Edit tool
 
 Bad: Consider parallel execution
 Good: Execute these commands in parallel (independent)
@@ -128,7 +134,7 @@ Nice-to-have: Minor formatting, additional examples
 ## Summary
 
 ### Files Modified
-- commands/example.md: [changes]
+- skills/example/SKILL.md: [changes]
 - CLAUDE.md: [changes]
 
 ### Improvements
@@ -153,13 +159,13 @@ Nice-to-have: Minor formatting, additional examples
 # Optimize all files (default behavior)
 optimize-ai-efficiency
 
-# Optimize specific command files
-optimize-ai-efficiency commands/verify-migration-connections.md
+# Optimize specific skill files
+optimize-ai-efficiency skills/verify-migration-connections/SKILL.md
 
 # Optimize multiple files
-optimize-ai-efficiency commands/foo.md commands/bar.md CLAUDE.md
+optimize-ai-efficiency skills/foo/SKILL.md skills/bar/SKILL.md CLAUDE.md
 
-# Note: Glob patterns like commands/verify-*.md are expanded by shell before passing to command
+# Note: Glob patterns like skills/verify-*/SKILL.md are expanded by shell before passing to skill
 ```
 
 ## Notes
@@ -167,7 +173,7 @@ optimize-ai-efficiency commands/foo.md commands/bar.md CLAUDE.md
 - Only apply changes when genuine optimizations are identified
 - Do not make unnecessary changes for the sake of changing
 - Preserve human readability
-- Do not change command functionality
+- Do not change skill functionality
 - Prefer explicit over implicit
 - If breaking changes: confirm with user first
 - When $ARGUMENTS specifies files, only those files are analyzed and modified

--- a/skills/restructure-issue/SKILL.md
+++ b/skills/restructure-issue/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: restructure-issue
+description: Restructure existing GitHub issue to clarify problem definition
+---
+
 Restructure existing GitHub issue $ARGUMENTS to clarify problem definition
 
 Output language: Japanese, formal business tone

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: review-pr
+description: Review GitHub Pull Request and provide insights for human reviewers
+---
+
 Review GitHub Pull Request and provide insights for human reviewers: $ARGUMENTS
 
 Output language: Japanese, formal business tone

--- a/skills/structure-issue/SKILL.md
+++ b/skills/structure-issue/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: structure-issue
+description: Create clear GitHub issue from user prompt
+---
+
 Create clear GitHub issue from user prompt: $ARGUMENTS
 
 Output language: Japanese, formal business tone

--- a/skills/verify-pr/SKILL.md
+++ b/skills/verify-pr/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: verify-pr
+description: Analyze PR implementation and provide verification instructions
+---
+
 Analyze PR implementation and provide verification instructions for $ARGUMENTS
 
 Output language: Japanese, formal business tone

--- a/skills/work-on-issue/SKILL.md
+++ b/skills/work-on-issue/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: work-on-issue
+description: Analyze and fix GitHub issue
+---
+
 Analyze and fix GitHub issue $ARGUMENTS
 
 Output language: Japanese, formal business tone


### PR DESCRIPTION
Commands to skills migration with YAML frontmatter and CLAUDE.md optimization.

## Changes

- Migrated 9 commands to skills/ with proper YAML frontmatter
- Added `disable-model-invocation: true` for improve-command and optimize-ai-efficiency
- Removed "Compile Errors" section from CLAUDE.md (reduced from 61 to 56 lines)
- Updated improve-command and optimize-ai-efficiency to use "skill" terminology instead of "command"
- Updated README.md to reflect skills-first approach with legacy commands note
- Preserved commands/aws-sdk-go-v2/ for backward compatibility

## Skills Created

- structure-issue, restructure-issue, answer-issue
- work-on-issue, review-pr, verify-pr, impl-review
- list-unresolved-pr-comments
- improve-command, optimize-ai-efficiency (manual invocation only)

Fixes #102